### PR TITLE
Make sure CardThread does not attempt to push more strips than fit in a packet.

### DIFF
--- a/src/com/heroicrobot/dropbit/devices/pixelpusher/CardThread.java
+++ b/src/com/heroicrobot/dropbit/devices/pixelpusher/CardThread.java
@@ -82,8 +82,13 @@ public class CardThread extends Thread {
     
     powerScale = registry.getPowerScale();
     
-    int stripPerPacket = pusher.getMaxStripsPerPacket();
     List<Strip> remainingStrips = new ArrayList<Strip>(pusher.getStrips());
+    final int requestedStripsPerPacket = pusher.getMaxStripsPerPacket();
+    final int supportedStripsPerPacket
+        = (this.packet.length - 4) / (1 + 3 * pusher.getPixelsPerStrip());
+    final int stripPerPacket = Math.min(requestedStripsPerPacket,
+                                        supportedStripsPerPacket);
+
     while (!remainingStrips.isEmpty()) {
       payload = false;
       if (pusher.getUpdatePeriod() > 100 && pusher.getUpdatePeriod() < 100000)


### PR DESCRIPTION
Hi,
Here the patch of what we discussed earlier - making the CardThread make sure that it not blindly uses what the controller claims to support but also what fits in the chosen packet size.

-henner
