### PR TITLE
Fixed some concurrency issues with PixelPusher.

### DIFF
--- a/src/com/heroicrobot/dropbit/devices/pixelpusher/CardThread.java
+++ b/src/com/heroicrobot/dropbit/devices/pixelpusher/CardThread.java
@@ -134,7 +134,7 @@ public class CardThread extends Thread {
     remainingStrips = new ArrayList<Strip>(pusher.getStrips());
     
     int requestedStripsPerPacket = pusher.getMaxStripsPerPacket();
-    int stripPerPacket = Math.min(requestedStripsPerPacket, pusher.stripsAttached);
+    int stripPerPacket = Math.min(requestedStripsPerPacket, pusher.stripsAttached.get());
 
     while (!remainingStrips.isEmpty()) {
       packetLength = 0;
@@ -143,12 +143,12 @@ public class CardThread extends Thread {
         this.threadSleepMsec = (pusher.getUpdatePeriod() / 1000) + 1;
       } else {
         // Shoot for the framelimit.
-        this.threadSleepMsec = ((1000/registry.getFrameLimit()) / (pusher.stripsAttached / stripPerPacket));
+        this.threadSleepMsec = ((1000/registry.getFrameLimit()) / (pusher.stripsAttached.get() / stripPerPacket));
       }
       
       // Handle errant delay calculation in the firmware.
       if (pusher.getUpdatePeriod() > 100000)
-        this.threadSleepMsec = (16 / (pusher.stripsAttached / stripPerPacket));
+        this.threadSleepMsec = (16 / (pusher.stripsAttached.get() / stripPerPacket));
       
       totalDelay = threadSleepMsec + threadExtraDelayMsec + pusher.getExtraDelay();
       


### PR DESCRIPTION
Fixed some obvious concurrency problems, but many remain.
All access to strips (both read and write) require the stripLock to be
held, including during iteration. This fixes
ConcurrentModificationException that occured during iteration.
Returning strips outside the class now returns a defensive copy to
prevent external mutation.

All multable fields are now intances of AtomicX to ensure that
mutations are visible in a multi-threaded environment. It is possible
that threads cache local copies of variables preventing those threads
from seeing the results of mutations. Using the AtomicX classes ensures
the visibility of field changes.
